### PR TITLE
Configured Travis CI to test on Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
         - MOLECULE_SCENARIO=opensuse
 
-# Require Ubuntu 14.04
-dist: trusty
+# Require Ubuntu 16.04
+dist: bionic
 
 # Require Docker
 services:
@@ -62,6 +62,7 @@ install:
   - ./moleculew wrapper-versions
 
 script:
+  - ifconfig
   - ./moleculew test --scenario-name=$MOLECULE_SCENARIO
 
 branches:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -20,14 +20,14 @@
       users:
         - username: test_usr1
           sdkman_install:
-            - candidate: jbang
-              version: '0.21.0'
-            - candidate: jbang
-              version: '0.20.0'
-            - candidate: jbang
-              version: '0.19.0'
-            - candidate: jbang
+            - candidate: asciidoctorj
+              version: '2.3.0'
+            - candidate: asciidoctorj
+              version: '2.2.0'
+            - candidate: asciidoctorj
+              version: '2.1.0'
+            - candidate: asciidoctorj
               version: 'tmp'
               path: '/tmp'
           sdkman_default:
-            jbang: '0.20.0'
+            asciidoctorj: '2.2.0'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -10,17 +10,17 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize('installed_version', [
     '+ tmp',
-    '* 0.21.0',
-    '* 0.20.0',
-    '* 0.19.0',
+    '* 2.3.0',
+    '* 2.2.0',
+    '* 2.1.0',
 ])
 def test_installed(host, installed_version):
-    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk list jbang'
+    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk list asciidoctorj'
     out = host.check_output("sudo --login --user=test_usr1 bash -c %s", cmd)
     assert installed_version in out
 
 
 def test_default(host):
-    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk current jbang'
+    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk current asciidoctorj'
     out = host.check_output("sudo --login --user=test_usr1 bash -c %s", cmd)
-    assert '0.20.0' in out
+    assert '2.2.0' in out

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: ~/.curlrc
+  become: yes
+  become_user: '{{ user.username }}'
+  copy:
+    content: '--http1.1'
+    dest: ~/.curlrc
+  loop_control:
+    loop_var: user
+  with_items: '{{ users }}'
+
 - name: install candidates
   become: yes
   become_user: '{{ item.0.username }}'

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,0 +1,5 @@
+sdkman_curl_connect_timeout=5
+sdkman_curl_continue=true
+sdkman_curl_max_time=10
+sdkman_curl_retry=3
+sdkman_curl_retry_max_time=30


### PR DESCRIPTION
As of the 13th of August 2019 Ubuntu Xenial is the default Linux distribution for Travis CI.