### PR TITLE
Switched tests from Ant to jbang

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -20,14 +20,14 @@
       users:
         - username: test_usr1
           sdkman_install:
-            - candidate: ant
-              version: '1.10.1'
-            - candidate: ant
-              version: '1.10.0'
-            - candidate: ant
-              version: '1.9.9'
-            - candidate: ant
+            - candidate: jbang
+              version: '0.21.0'
+            - candidate: jbang
+              version: '0.20.0'
+            - candidate: jbang
+              version: '0.19.0'
+            - candidate: jbang
               version: 'tmp'
               path: '/tmp'
           sdkman_default:
-            ant: '1.10.0'
+            jbang: '0.20.0'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -10,17 +10,17 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize('installed_version', [
     '+ tmp',
-    '* 1.10.1',
-    '* 1.10.0',
-    '* 1.9.9',
+    '* 0.21.0',
+    '* 0.20.0',
+    '* 0.19.0',
 ])
 def test_installed(host, installed_version):
-    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk list ant'
+    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk list jbang'
     out = host.check_output("sudo --login --user=test_usr1 bash -c %s", cmd)
     assert installed_version in out
 
 
 def test_default(host):
-    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk current ant'
+    cmd = 'source ~/.sdkman/bin/sdkman-init.sh && sdk current jbang'
     out = host.check_output("sudo --login --user=test_usr1 bash -c %s", cmd)
-    assert '1.10.0' in out
+    assert '0.20.0' in out


### PR DESCRIPTION
The SDKMAN! version of Ant is very out of date and downloads of these old versions are slow and unreliable.