### PR TITLE
Increased upper Debian test version to Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Requirements
 
             * Jessie (8)
             * Stretch (9)
+            * Buster (10)
+            * Bullseye (11)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,8 @@ galaxy_info:
       versions:
         - jessie
         - stretch
+        - buster
+        - bullseye
     - name: opensuse
       versions:
         - 15.1

--- a/molecule/debian_max/molecule.yml
+++ b/molecule/debian_max/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_sdkman_init_debian_max
-    image: debian:9
+    image: debian:11
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Bullseye is the latest stable version of Debian.